### PR TITLE
feat: add `qs_accepted_chars` as a configurable option

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = "com.joshestein"
-version = "1.0.7"
+version = "1.0.8"
 
 repositories {
     mavenCentral()

--- a/src/main/kotlin/com/joshestein/ideavimquickscope/IdeaVimQuickscopeExtension.kt
+++ b/src/main/kotlin/com/joshestein/ideavimquickscope/IdeaVimQuickscopeExtension.kt
@@ -16,15 +16,14 @@ import com.maddyhome.idea.vim.extension.VimExtensionFacade.putKeyMappingIfMissin
 import com.maddyhome.idea.vim.extension.VimExtensionHandler
 import com.maddyhome.idea.vim.helper.StringHelper.parseKeys
 import com.maddyhome.idea.vim.vimscript.model.datatypes.VimList
-import com.maddyhome.idea.vim.vimscript.model.datatypes.VimString
 import java.awt.event.KeyEvent
 
 private enum class Direction { FORWARD, BACKWARD }
 
 private var ACCEPTED_CHARS = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789".toCharArray()
 
-private const val HIGHLIGHT_ON_KEYS_VARIABLE = "qs_highlight_on_keys"
 private const val ACCEPTED_CHARS_VARIABLE = "qs_accepted_chars"
+private const val HIGHLIGHT_ON_KEYS_VARIABLE = "qs_highlight_on_keys"
 
 class Listener : CaretListener {
     private lateinit var highlighter: Highlighter
@@ -49,10 +48,10 @@ class IdeaVimQuickscopeExtension : VimExtension {
 
         if (userAcceptedChars != null && userAcceptedChars is VimList) {
             ACCEPTED_CHARS = userAcceptedChars.values
-                .filter { (it is VimString) && it.value.isNotBlank() }
-                .map { it.asString()[0] }
-                .toTypedArray().toCharArray()
+                .joinToString("")
+                .toCharArray()
         }
+
         if (highlightKeys != null && highlightKeys is VimList) {
             // Only add highlights after pressing one of the variable keys (e.g. "f", "t", "F", "T")
             for (value in highlightKeys.values) {

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -55,7 +55,7 @@
     <change-notes><![CDATA[
     <h3>1.0.8</h3>
     <ul>
-        <li>Introduce <code>g:accepted_chars</code> to allow the use of custom accepted characters when highlighting</li>
+        <li>Introduce <code>g:qs_accepted_chars</code> to allow the use of custom accepted characters when highlighting.</li>
     </ul>
     <h3>1.0.7</h3>
     <ul>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -38,6 +38,10 @@
         Use <code>let g:qs_highlight_on_keys = ['f', 'F', 't', 'T']</code> to configure which keys to highlight on. Alternatively,
         do not set this variable to always show highlights.
         <br>
+        Use <code>let g:qs_accepted_chars = ['a', 'b', ... ]</code> to configure accepted characters to be used when highlighting.
+        To keep the default characters while appending new characters, please use the following and append characters as you see fit: <br>
+        <code>let g:qs_accepted_chars = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z', 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9']</code>
+        <br>
         Use <code>let g:qs_primary_color = '#ff0000'</code> to configure the first occurrence character color. Please use a hex color.
         <br>
         Use <code>let g:qs_secondary_color = '#ff00ff'</code> to configure the second occurrence character color. Again, please use a hex color.
@@ -49,6 +53,10 @@
   ]]></description>
 
     <change-notes><![CDATA[
+    <h3>1.0.8</h3>
+    <ul>
+        <li>Introduce <code>g:accepted_chars</code> to allow the use of custom accepted characters when highlighting</li>
+    </ul>
     <h3>1.0.7</h3>
     <ul>
         <li>Update compatibility for IDE versions 223.*</li>


### PR DESCRIPTION
The behaviour of this option follows the original defined within [quick-scope](https://github.com/unblevable/quick-scope#accepted-characters)

closes #5 