### PR TITLE
Improve handling of default colours

### DIFF
--- a/.idea/.name
+++ b/.idea/.name
@@ -1,0 +1,1 @@
+ideavim-quickscope

--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="KotlinJpsPluginSettings">
+    <option name="version" value="1.6.20" />
+  </component>
+</project>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = "com.joshestein"
-version = "1.0.10"
+version = "1.0.11"
 
 repositories {
     mavenCentral()

--- a/src/main/kotlin/com/joshestein/ideavimquickscope/Highlighter.kt
+++ b/src/main/kotlin/com/joshestein/ideavimquickscope/Highlighter.kt
@@ -27,6 +27,8 @@ class Highlighter(var editor: Editor) {
             color.brighter().takeIf { it != color } ?: color.darker()
         }
     }
+    private val primaryTextAttributes = this.getHighlightTextAttributes(true)
+    private val secondaryTextAttributes = this.getHighlightTextAttributes(false)
     private val highlighters: MutableSet<RangeHighlighter> = mutableSetOf()
 
     fun updateEditor(editor: Editor) {
@@ -35,28 +37,27 @@ class Highlighter(var editor: Editor) {
     }
 
     fun addHighlights(highlights: List<Highlight>) {
-        val primary = getPrimaryHighlightTextAttributes()
-        val secondary = getSecondaryHighlightTextAttributes()
-
         highlights.forEach { highlight ->
             highlighters.add(
                 this.editor.markupModel.addRangeHighlighter(
                     highlight.position,
                     highlight.position + 1,
                     HighlighterLayer.SELECTION,
-                    if (highlight.primary) primary else secondary,
+                    if (highlight.primary) primaryTextAttributes else secondaryTextAttributes,
                     HighlighterTargetArea.EXACT_RANGE
                 )
             )
         }
     }
 
-    private fun getPrimaryHighlightTextAttributes(): TextAttributes {
-        return TextAttributes(primaryColor, null, primaryColor, EffectType.BOLD_LINE_UNDERSCORE, Font.BOLD)
-    }
-
-    private fun getSecondaryHighlightTextAttributes(): TextAttributes {
-        return TextAttributes(secondaryColor, null, secondaryColor, EffectType.LINE_UNDERSCORE, Font.PLAIN)
+    private fun getHighlightTextAttributes(primary: Boolean): TextAttributes {
+        return TextAttributes(
+            if (primary) primaryColor else secondaryColor,
+            null,
+            if (primary) primaryColor else secondaryColor,
+            if (primary) EffectType.BOLD_LINE_UNDERSCORE else EffectType.LINE_UNDERSCORE,
+            if (primary) Font.BOLD else Font.PLAIN
+        )
     }
 
     fun removeHighlights() {

--- a/src/main/kotlin/com/joshestein/ideavimquickscope/Highlighter.kt
+++ b/src/main/kotlin/com/joshestein/ideavimquickscope/Highlighter.kt
@@ -13,13 +13,13 @@ private const val SECONDARY_COLOR_VARIABLE = "qs_secondary_color"
 data class Highlight(val position: Int, val primary: Boolean)
 
 class Highlighter(var editor: Editor) {
-    private var primaryColor: Color = try {
+    private val primaryColor: Color = try {
         Color.decode(VimPlugin.getVariableService().getGlobalVariableValue(PRIMARY_COLOR_VARIABLE).toString())
     } catch (e: Exception) {
         editor.colorsScheme.getAttributes(EditorColors.REFERENCE_HYPERLINK_COLOR)?.foregroundColor
             ?: EditorColors.REFERENCE_HYPERLINK_COLOR.defaultAttributes.foregroundColor
     }
-    private var secondaryColor: Color = try {
+    private val secondaryColor: Color = try {
         Color.decode(VimPlugin.getVariableService().getGlobalVariableValue(SECONDARY_COLOR_VARIABLE).toString())
     } catch (e: Exception) {
         (editor.colorsScheme.getAttributes(EditorColors.REFERENCE_HYPERLINK_COLOR)?.foregroundColor

--- a/src/main/kotlin/com/joshestein/ideavimquickscope/Highlighter.kt
+++ b/src/main/kotlin/com/joshestein/ideavimquickscope/Highlighter.kt
@@ -13,15 +13,19 @@ private const val SECONDARY_COLOR_VARIABLE = "qs_secondary_color"
 data class Highlight(val position: Int, val primary: Boolean)
 
 class Highlighter(var editor: Editor) {
-    private var primaryColor: Color? = try {
+    private var primaryColor: Color = try {
         Color.decode(VimPlugin.getVariableService().getGlobalVariableValue(PRIMARY_COLOR_VARIABLE).toString())
     } catch (e: Exception) {
-        null
+        editor.colorsScheme.getAttributes(EditorColors.REFERENCE_HYPERLINK_COLOR)?.foregroundColor
+            ?: EditorColors.REFERENCE_HYPERLINK_COLOR.defaultAttributes.foregroundColor
     }
-    private var secondaryColor: Color? = try {
+    private var secondaryColor: Color = try {
         Color.decode(VimPlugin.getVariableService().getGlobalVariableValue(SECONDARY_COLOR_VARIABLE).toString())
     } catch (e: Exception) {
-        null
+        (editor.colorsScheme.getAttributes(EditorColors.REFERENCE_HYPERLINK_COLOR)?.foregroundColor
+            ?: EditorColors.REFERENCE_HYPERLINK_COLOR.defaultAttributes.foregroundColor).let { color ->
+            color.brighter().takeIf { it != color } ?: color.darker()
+        }
     }
     private val highlighters: MutableSet<RangeHighlighter> = mutableSetOf()
 
@@ -48,23 +52,11 @@ class Highlighter(var editor: Editor) {
     }
 
     private fun getPrimaryHighlightTextAttributes(): TextAttributes {
-        // Get the fallback color each time, so we cope with theme changes. We can't do anything for user configured
-        // colors without some autocmd mechanism
-        val color = primaryColor ?: run {
-            editor.colorsScheme.getAttributes(EditorColors.REFERENCE_HYPERLINK_COLOR)?.foregroundColor
-                ?: EditorColors.REFERENCE_HYPERLINK_COLOR.defaultAttributes.foregroundColor
-        }
-        return TextAttributes(color, null, color, EffectType.BOLD_LINE_UNDERSCORE, Font.BOLD)
+        return TextAttributes(primaryColor, null, primaryColor, EffectType.BOLD_LINE_UNDERSCORE, Font.BOLD)
     }
 
     private fun getSecondaryHighlightTextAttributes(): TextAttributes {
-        val color = secondaryColor ?: run {
-            (editor.colorsScheme.getAttributes(EditorColors.REFERENCE_HYPERLINK_COLOR)?.foregroundColor
-                ?: EditorColors.REFERENCE_HYPERLINK_COLOR.defaultAttributes.foregroundColor).let { color ->
-                color.brighter().takeIf { it != color } ?: color.darker()
-            }
-        }
-        return TextAttributes(color, null, color, EffectType.LINE_UNDERSCORE, Font.PLAIN)
+        return TextAttributes(secondaryColor, null, secondaryColor, EffectType.LINE_UNDERSCORE, Font.PLAIN)
     }
 
     fun removeHighlights() {

--- a/src/main/kotlin/com/joshestein/ideavimquickscope/Highlighter.kt
+++ b/src/main/kotlin/com/joshestein/ideavimquickscope/Highlighter.kt
@@ -60,7 +60,9 @@ class Highlighter(var editor: Editor) {
     private fun getSecondaryHighlightTextAttributes(): TextAttributes {
         val color = secondaryColor ?: run {
             (editor.colorsScheme.getAttributes(EditorColors.REFERENCE_HYPERLINK_COLOR)?.foregroundColor
-            ?: EditorColors.REFERENCE_HYPERLINK_COLOR.defaultAttributes.foregroundColor).brighter()
+                ?: EditorColors.REFERENCE_HYPERLINK_COLOR.defaultAttributes.foregroundColor).let { color ->
+                color.brighter().takeIf { it != color } ?: color.darker()
+            }
         }
         return TextAttributes(color, null, color, EffectType.LINE_UNDERSCORE, Font.PLAIN)
     }

--- a/src/main/kotlin/com/joshestein/ideavimquickscope/Highlighter.kt
+++ b/src/main/kotlin/com/joshestein/ideavimquickscope/Highlighter.kt
@@ -54,7 +54,7 @@ class Highlighter(var editor: Editor) {
             editor.colorsScheme.getAttributes(EditorColors.REFERENCE_HYPERLINK_COLOR)?.foregroundColor
                 ?: EditorColors.REFERENCE_HYPERLINK_COLOR.defaultAttributes.foregroundColor
         }
-        return TextAttributes(color, null, color, EffectType.LINE_UNDERSCORE, Font.PLAIN)
+        return TextAttributes(color, null, color, EffectType.BOLD_LINE_UNDERSCORE, Font.BOLD)
     }
 
     private fun getSecondaryHighlightTextAttributes(): TextAttributes {

--- a/src/main/kotlin/com/joshestein/ideavimquickscope/Highlighter.kt
+++ b/src/main/kotlin/com/joshestein/ideavimquickscope/Highlighter.kt
@@ -10,21 +10,18 @@ import java.awt.Font
 private const val PRIMARY_COLOR_VARIABLE = "qs_primary_color"
 private const val SECONDARY_COLOR_VARIABLE = "qs_secondary_color"
 
-private val DEFAULT_PRIMARY_COLOR = EditorColors.REFERENCE_HYPERLINK_COLOR.defaultAttributes.foregroundColor
-private val DEFAULT_SECONDARY_COLOR = DEFAULT_PRIMARY_COLOR.brighter()
-
 data class Highlight(val position: Int, val primary: Boolean)
 
 class Highlighter(var editor: Editor) {
     private var primaryColor: Color? = try {
         Color.decode(VimPlugin.getVariableService().getGlobalVariableValue(PRIMARY_COLOR_VARIABLE).toString())
     } catch (e: Exception) {
-        DEFAULT_PRIMARY_COLOR
+        null
     }
     private var secondaryColor: Color? = try {
         Color.decode(VimPlugin.getVariableService().getGlobalVariableValue(SECONDARY_COLOR_VARIABLE).toString())
     } catch (e: Exception) {
-        DEFAULT_SECONDARY_COLOR
+        null
     }
     private val highlighters: MutableSet<RangeHighlighter> = mutableSetOf()
 
@@ -34,26 +31,39 @@ class Highlighter(var editor: Editor) {
     }
 
     fun addHighlights(highlights: List<Highlight>) {
+        val primary = getPrimaryHighlightTextAttributes()
+        val secondary = getSecondaryHighlightTextAttributes()
+
         highlights.forEach { highlight ->
             highlighters.add(
                 this.editor.markupModel.addRangeHighlighter(
                     highlight.position,
                     highlight.position + 1,
                     HighlighterLayer.SELECTION,
-                    getHighlightTextAttributes(highlight.primary),
+                    if (highlight.primary) primary else secondary,
                     HighlighterTargetArea.EXACT_RANGE
                 )
             )
         }
     }
 
-    private fun getHighlightTextAttributes(primary: Boolean) = TextAttributes(
-        if (primary) primaryColor else secondaryColor,
-        null,
-        if (primary) primaryColor else secondaryColor,
-        EffectType.LINE_UNDERSCORE,
-        Font.PLAIN
-    )
+    private fun getPrimaryHighlightTextAttributes(): TextAttributes {
+        // Get the fallback color each time, so we cope with theme changes. We can't do anything for user configured
+        // colors without some autocmd mechanism
+        val color = primaryColor ?: run {
+            editor.colorsScheme.getAttributes(EditorColors.REFERENCE_HYPERLINK_COLOR)?.foregroundColor
+                ?: EditorColors.REFERENCE_HYPERLINK_COLOR.defaultAttributes.foregroundColor
+        }
+        return TextAttributes(color, null, color, EffectType.LINE_UNDERSCORE, Font.PLAIN)
+    }
+
+    private fun getSecondaryHighlightTextAttributes(): TextAttributes {
+        val color = secondaryColor ?: run {
+            (editor.colorsScheme.getAttributes(EditorColors.REFERENCE_HYPERLINK_COLOR)?.foregroundColor
+            ?: EditorColors.REFERENCE_HYPERLINK_COLOR.defaultAttributes.foregroundColor).brighter()
+        }
+        return TextAttributes(color, null, color, EffectType.LINE_UNDERSCORE, Font.PLAIN)
+    }
 
     fun removeHighlights() {
         highlighters.forEach { highlighter ->

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -53,6 +53,11 @@
   ]]></description>
 
     <change-notes><![CDATA[
+    <h3>1.0.11</h3>
+    <ul>
+        <li>Improved default colors.</li>
+        <li>Bold font and bold underline for primary matches.</li>
+    </ul>
     <h3>1.0.10</h3>
     <ul>
         <li>Build for all future versions of IDEs.</li>


### PR DESCRIPTION
This PR makes some minor changes to the highlights if you don't set your own custom colours:

* Use the default colours for the current editor theme, rather than just the default attributes. This works better with dark themes
* Calculate the default colours when adding highlights, which means colours are correct after a theme change
* Verify that the secondary colour is actually modified by the call to `brighter()`. If not, use `darker()` to get a different colour
* Use bold font and underline for the primary matches to help distinguish between primary and secondary matches by something other than colour, which is very helpful for my mild colourblindness