### PR TITLE
Fix handling of VimString for keys

### DIFF
--- a/src/main/kotlin/com/joshestein/ideavimquickscope/IdeaVimQuickscopeExtension.kt
+++ b/src/main/kotlin/com/joshestein/ideavimquickscope/IdeaVimQuickscopeExtension.kt
@@ -21,6 +21,7 @@ import com.maddyhome.idea.vim.extension.VimExtensionHandler
 import com.maddyhome.idea.vim.helper.StringHelper.parseKeys
 import com.maddyhome.idea.vim.vimscript.model.datatypes.VimInt
 import com.maddyhome.idea.vim.vimscript.model.datatypes.VimList
+import com.maddyhome.idea.vim.vimscript.model.datatypes.VimString
 import java.awt.event.KeyEvent
 
 private enum class Direction { FORWARD, BACKWARD }
@@ -62,25 +63,27 @@ class IdeaVimQuickscopeExtension : VimExtension {
 
         if (userAcceptedChars != null && userAcceptedChars is VimList) {
             ACCEPTED_CHARS = userAcceptedChars.values
-                .joinToString("")
+                .joinToString("") { (it as? VimString)?.value ?: "" }
                 .toCharArray()
         }
 
         if (highlightKeys != null && highlightKeys is VimList) {
             // Only add highlights after pressing one of the variable keys (e.g. "f", "t", "F", "T")
             for (value in highlightKeys.values) {
+                // TODO: When using a newer version of IdeaVim, we can use value.toVimString().value
+                val string = (value as? VimString)?.value ?: continue
                 putExtensionHandlerMapping(
                     MappingMode.NXO,
-                    parseKeys("<Plug>quickscope-$value"),
+                    parseKeys("<Plug>quickscope-${string}"),
                     owner,
-                    QuickscopeHandler(value.toString()[0]),
+                    QuickscopeHandler(string[0]),
                     false
                 )
                 putKeyMappingIfMissing(
                     MappingMode.NXO,
-                    parseKeys(value.toString()),
+                    parseKeys(string),
                     owner,
-                    parseKeys("<Plug>quickscope-$value"),
+                    parseKeys("<Plug>quickscope-$string"),
                     true
                 )
             }


### PR DESCRIPTION
This extension uses a list declared in the `g:qs_highlight_on_keys` variable to configure the keys used in the mappings, using each list element in the `<Plug>quickscope-{char}` mapping.

A recent update to IdeaVim (JetBrains/ideavim#1300) made some changes to the API of `VimDataType` to make getting the value of the object more explicit (if the caller wants a Number, it should call `toVimNumber().value`, if it wants a String, it should call `toVimString().value`. This makes the caller's intent/requirements explicit, and handles data conversion when applicable.)

As part of these changes, `VimDataType.toString()` has been deprecated as a way to get a string representation of the datatype. This was never a reliable API - it could be called implicitly and unexpectedly, and it was unclear what the returned string value could be used for (output for error messages, inserting into text, an actual string value). It also didn't handle data conversion properly (e.g. a Number can be converted to a String, but not a Float or a List. `toString()` didn't handle this)

The upshot is that `toString` now returns traditional `toString` values, most useful for debugging, such as `VimString(F)`. This breaks registration of Quickscope, as the key mapping is now created as `<Plug>quickscope-VimString(F)`, and this is mapped to the `VimString(F)` keys.

This PR fixes this by getting the string value of the datatype, for `g:qs_highlight_on_keys` and `g:qs_accepted_chars`. Because the extension is built against an older version of IdeaVim, it has to check the type and upcast to `VimString`, and it can then get the string from the `value` property. The current API would allow calling `VimDataType.toVimString().value`, which will take care of any data conversions, or throw the appropriate exception.